### PR TITLE
Fixes issue where object wouldn't be used with NSNotification logging

### DIFF
--- a/Antenna/Antenna.m
+++ b/Antenna/Antenna.m
@@ -192,13 +192,13 @@ inManagedObjectContext:(NSManagedObjectContext *)context;
                               object:(id)object
 {
     __weak __typeof(self)weakSelf = self;
-    [self startLoggingNotificationName:name object:nil constructingPayLoadFromBlock:^NSDictionary *(NSNotification *notification) {
+    [self startLoggingNotificationName:name object:object constructingPayLoadFromBlock:^NSDictionary *(NSNotification *notification) {
         __strong __typeof(weakSelf)strongSelf = weakSelf;
 
         NSMutableDictionary *mutablePayload = [strongSelf.defaultPayload mutableCopy];
         if (notification.userInfo) {
-            [notification.userInfo enumerateKeysAndObjectsUsingBlock:^(id key, __unused id obj, __unused BOOL *stop) {
-                [mutablePayload setObject:object forKey:key];
+            [notification.userInfo enumerateKeysAndObjectsUsingBlock:^(id key, id obj, __unused BOOL *stop) {
+                [mutablePayload setObject:obj forKey:key];
             }];
         }
         [mutablePayload setObject:name forKey:@"notification"];


### PR DESCRIPTION
Also fixes assumed issue where userInfo objects weren't being passed to logging payload instead the NSNotification object was passed.
