### PR TITLE
fix warnings in new Xcode

### DIFF
--- a/Antenna/Antenna.m
+++ b/Antenna/Antenna.m
@@ -307,7 +307,11 @@ requestSerializer:(AFHTTPRequestSerializer <AFURLRequestSerialization> *)request
 
 - (void)log:(NSDictionary *)payload {
     NSURLRequest *request = [self.requestSerializer requestWithMethod:self.method URLString:[self.URL absoluteString] parameters:payload error:nil];
-    [NSURLConnection sendAsynchronousRequest:request queue:self.operationQueue completionHandler:nil];
+    [NSURLConnection sendAsynchronousRequest:request
+                                       queue:self.operationQueue
+     completionHandler:^(NSURLResponse *response, NSData *data, NSError *connectionError) {
+
+     }];
 }
 
 @end
@@ -344,7 +348,7 @@ inManagedObjectContext:(NSManagedObjectContext *)context
 
 - (void)log:(NSDictionary *)payload {
     [self.context performBlock:^{
-        NSManagedObjectContext *entry = [NSEntityDescription insertNewObjectForEntityForName:self.entity.name inManagedObjectContext:self.context];
+        NSManagedObject *entry = [NSEntityDescription insertNewObjectForEntityForName:self.entity.name inManagedObjectContext:self.context];
         [entry setValue:AntennaLogLineFromPayload(payload) forKey:self.messageAttribute.name];
         [entry setValue:[NSDate date] forKey:self.timestampAttribute.name];
 


### PR DESCRIPTION
1. Pass in empty block to get around nonnull warnings in the new SDK
2. NSManagedObject is returned by - [NSEntityDescription insertNewObjectForEntityForName:inManagedObjectContext], not NSManagedObjectContext.
